### PR TITLE
Remove unused dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,6 @@ http = "0.2.4"
 k8s-openapi = { version = "0.13.0", features = ["v1_21"] }
 serde = { version = "1.0.127", features = ["derive"] }
 serde_yaml = "0.8.17"
-openssl = "0.10.35"
-url = "2.2.2"
-#oauth2 = "4.1.0"
 base64 = "0.13.0"
 chrono = "0.4.19"
 dirs = "3.0.2"


### PR DESCRIPTION
Hey,

While troubleshooting a build failure of scaphandre noticed there was a `open-ssl` dependency coming from that crate which is no longer used, along `url`.

Thanks for your work on `scaphandre`! We use it internally at https://lichess.org, the largest open-source chess website 